### PR TITLE
Add linked token model exposed via graphql

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'jbuilder', '~> 2.7'
 # gem 'bcrypt', '~> 3.1.7'
 
 gem "graphql"
+gem "graphiql-rails"
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
     ffi (1.12.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    graphiql-rails (1.7.0)
+      railties
+      sprockets-rails
     graphql (1.10.5)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
@@ -197,6 +200,7 @@ DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
   capybara (>= 2.15)
+  graphiql-rails
   graphql
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+//= link graphiql/rails/application.css
+//= link graphiql/rails/application.js

--- a/app/graphql/feed_a_doc_schema.rb
+++ b/app/graphql/feed_a_doc_schema.rb
@@ -1,6 +1,6 @@
 class FeedADocSchema < GraphQL::Schema
-  mutation(Types::MutationType)
   query(Types::QueryType)
+  mutation(Types::MutationType)
 
   # Opt in to the new runtime (default in future graphql-ruby versions)
   use GraphQL::Execution::Interpreter

--- a/app/graphql/mutations/create_provider_and_request.rb
+++ b/app/graphql/mutations/create_provider_and_request.rb
@@ -40,6 +40,7 @@ class Mutations::CreateProviderAndRequest < Mutations::BaseMutation
     if provider.valid? && request.valid?
       provider.save!
       request.save!
+      LinkCreator.create(request)
       {
         provider: provider,
         request: request,

--- a/app/graphql/types/linked_token_entity_union_type.rb
+++ b/app/graphql/types/linked_token_entity_union_type.rb
@@ -1,0 +1,12 @@
+class Types::LinkedTokenEntityUnionType < Types::BaseUnion
+  description 'Represents either a Provider or Request'
+  possible_types Types::Provider, Types::Request
+  def self.resolve_type(object, _context)
+    case object
+    when Provider then Types::Provider
+    when Request then Types::Request
+    else
+      raise "Unknown linked token type"
+    end
+  end
+end

--- a/app/graphql/types/linked_token_type.rb
+++ b/app/graphql/types/linked_token_type.rb
@@ -1,0 +1,6 @@
+module Types
+  class LinkedTokenType < Types::BaseObject
+    field :id, ID, null: false
+    field :entity, Types::LinkedTokenEntityUnionType, null: false
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -40,5 +40,14 @@ module Types
 
       scope
     end
+
+    field :linked_token,
+          Types::LinkedTokenEntityUnionType,
+          null: false do
+      argument :token, String, required: true
+    end
+    def linked_token(args)
+      LinkedToken.find_by(token: args[:token]).entity
+    end
   end
 end

--- a/app/models/linked_token.rb
+++ b/app/models/linked_token.rb
@@ -1,3 +1,10 @@
 class LinkedToken < ApplicationRecord
   belongs_to :entity, polymorphic: true
+  before_validation :set_token, on: :create
+
+  private
+
+  def set_token
+    self.token ||= SecureRandom.uuid
+  end
 end

--- a/app/models/linked_token.rb
+++ b/app/models/linked_token.rb
@@ -1,0 +1,3 @@
+class LinkedToken < ApplicationRecord
+  belongs_to :entity, polymorphic: true
+end

--- a/app/services/link_creator.rb
+++ b/app/services/link_creator.rb
@@ -1,7 +1,7 @@
 class LinkCreator
   class << self
     def create(entity)
-      LinkedToken.create!(entity: entity, token: SecureRandom.uuid)
+      LinkedToken.create!(entity: entity)
     end
   end
 end

--- a/app/services/link_creator.rb
+++ b/app/services/link_creator.rb
@@ -1,0 +1,7 @@
+class LinkCreator
+  class << self
+    def create(entity)
+      LinkedToken.create!(entity: entity, token: SecureRandom.uuid)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  mount GraphiQL::Rails::Engine, at: "/graphiql", graphql_path: "/graphql" if Rails.env.development?
   post "/graphql", to: "graphql#execute"
   root 'home#index'
   match '*path' => 'home#index', via: :get

--- a/db/migrate/20200319055350_create_linked_tokens.rb
+++ b/db/migrate/20200319055350_create_linked_tokens.rb
@@ -1,10 +1,13 @@
 class CreateLinkedTokens < ActiveRecord::Migration[6.0]
   def change
     create_table :linked_tokens do |t|
-      t.string :token
+      t.string :token, null: false
       t.references :entity, polymorphic: true, null: false
 
       t.timestamps
+
+      t.index :token, unique: true
+      t.index [:token, :entity_type, :entity_id]
     end
   end
 end

--- a/db/migrate/20200319055350_create_linked_tokens.rb
+++ b/db/migrate/20200319055350_create_linked_tokens.rb
@@ -1,0 +1,10 @@
+class CreateLinkedTokens < ActiveRecord::Migration[6.0]
+  def change
+    create_table :linked_tokens do |t|
+      t.string :token
+      t.references :entity, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_16_204230) do
+ActiveRecord::Schema.define(version: 2020_03_19_055350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "linked_tokens", force: :cascade do |t|
+    t.string "token"
+    t.string "entity_type", null: false
+    t.bigint "entity_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["entity_type", "entity_id"], name: "index_linked_tokens_on_entity_type_and_entity_id"
+  end
 
   create_table "providers", force: :cascade do |t|
     t.string "first_name", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,12 +16,14 @@ ActiveRecord::Schema.define(version: 2020_03_19_055350) do
   enable_extension "plpgsql"
 
   create_table "linked_tokens", force: :cascade do |t|
-    t.string "token"
+    t.string "token", null: false
     t.string "entity_type", null: false
     t.bigint "entity_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["entity_type", "entity_id"], name: "index_linked_tokens_on_entity_type_and_entity_id"
+    t.index ["token", "entity_type", "entity_id"], name: "index_linked_tokens_on_token_and_entity_type_and_entity_id"
+    t.index ["token"], name: "index_linked_tokens_on_token", unique: true
   end
 
   create_table "providers", force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   web:
     build: .
     container_name: feedadoc_web
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: bash -c "bundle && rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     environment:
       PGHOST: "dev_db"
       WEBPACKER_DEV_SERVER_HOST: "webpacker"

--- a/test/fixtures/linked_tokens.yml
+++ b/test/fixtures/linked_tokens.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  token: MyText
+  entity: one
+  entity_type: entity
+
+two:
+  token: MyText
+  entity: two
+  entity_type: entity

--- a/test/models/linked_token_test.rb
+++ b/test/models/linked_token_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class LinkedTokenTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
The goal here is to be able to provide users with a custom link to edit an entity. This puts us most of the way there.

When an entity (request or response) is created, we also create a LinkedToken. This token holds a reference to the entity allowing anyone that knows the token to edit it.

Query:
```
{
  linkedToken(token: "3be17075-d86e-4bec-accc-ca241abe486e") {
    ...on Request {
      provider {
        id
      }
    }
  }
}
```