### PR TITLE
Render recent provider requests

### DIFF
--- a/app/graphql/filter_helpers.rb
+++ b/app/graphql/filter_helpers.rb
@@ -1,7 +1,6 @@
 module FilterHelpers
   def where(filters)
-    processed_filters = process_filters(filters)
-    processed_filters.with_indifferent_access
+    filters.to_h.with_indifferent_access
   end
 
   def order(order_by)
@@ -10,19 +9,5 @@ module FilterHelpers
     o = {}
     o[key] = value
     o
-  end
-
-  def process_filters(filters)
-    processed_filters = {}
-
-    filters.map do |key, value|
-      if key == :updated_within_days
-        processed_filters['updated_at'] = (DateTime.now - value)..DateTime.now
-      else
-        processed_filters[key] = value
-      end
-    end
-
-    processed_filters
   end
 end

--- a/app/graphql/filter_helpers.rb
+++ b/app/graphql/filter_helpers.rb
@@ -1,6 +1,7 @@
 module FilterHelpers
   def where(filters)
-    filters.to_h.with_indifferent_access
+    processed_filters = process_filters(filters)
+    processed_filters.with_indifferent_access
   end
 
   def order(order_by)
@@ -9,5 +10,19 @@ module FilterHelpers
     o = {}
     o[key] = value
     o
+  end
+
+  def process_filters(filters)
+    processed_filters = {}
+
+    filters.map do |key, value|
+      if key == :updated_within_days
+        processed_filters['updated_at'] = (DateTime.now - value)..DateTime.now
+      else
+        processed_filters[key] = value
+      end
+    end
+
+    processed_filters
   end
 end

--- a/app/graphql/types/provider.rb
+++ b/app/graphql/types/provider.rb
@@ -10,6 +10,7 @@ module Types
     field :description, String, null: false
     field :requests, [Types::Request], null: false
     field :active, Boolean, null: false
+    field :updated_at, String, null: false
   end
 
   class ProviderFilter < Types::BaseInputObject
@@ -18,6 +19,7 @@ module Types
     argument :city, String, required: false
     argument :active, Boolean, required: false
     argument :role, String, required: false
+    argument :updated_within_days, Int, required: false
   end
 
   class ProviderSort < Types::BaseEnum

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -11,7 +11,13 @@ module Types
       argument :order_by, Types::ProviderOrder, required: false
     end
     def providers(filters: nil, order_by: nil)
-      ::Provider.where(where(filters)).order(order(order_by))
+      filters = filters.to_h
+      updated_within_days = filters.delete(:updated_within_days)
+      scope = ::Provider.where(where(filters)).order(order(order_by))
+      if updated_within_days
+        scope = scope.where("updated_at > ?", updated_within_days.days.ago)
+      end
+      scope
     end
 
     field :linked_token,

--- a/app/javascript/packs/pages/BrowseRequests.jsx
+++ b/app/javascript/packs/pages/BrowseRequests.jsx
@@ -22,7 +22,10 @@ const useStyles = makeStyles(theme => ({
 
 const TOTAL_PROVIDERS = gql`
   {
-    providers(filters: { active: true }, orderBy: { direction: ASC, sort: CITY }) {
+    providers(filters: {
+      active: true
+      updatedWithinDays: 15
+    }, orderBy: { direction: ASC, sort: CITY }) {
       totalCount
 
       pageInfo {
@@ -41,6 +44,7 @@ const TOTAL_PROVIDERS = gql`
           id, firstName
           city, state, neighborhood
           role, facility
+          updatedAt
         }
       }
     }


### PR DESCRIPTION
https://trello.com/c/kZ9jxlo3/16-provider-request-expires-after-14-days

## Overview

This PR adds a `updated_within_days` filter option for provider requests so that the client may fetch only recent PR's.