### PR TITLE
Ensure only requests listed by the provider are on the volunteer form

### DIFF
--- a/app/javascript/packs/pages/volunteer_signup/OfferForm.jsx
+++ b/app/javascript/packs/pages/volunteer_signup/OfferForm.jsx
@@ -65,7 +65,8 @@ export default function OfferForm({
   availabilities,
   description,
   onChange,
-  setField
+  setField,
+  provider
 }) {
   const classes = useStyles();
 
@@ -98,29 +99,36 @@ export default function OfferForm({
             <FormLabel required id="type-select-label">
               What can you help with?
             </FormLabel>
-            {providerRequestTypes.map(type => (
-              <FormControlLabel
-                key={type.value}
-                control={
-                  <Checkbox
-                    checked={requests.includes(type.value)}
-                    onChange={e =>
-                      e.target.checked
-                        ? setField("requests")([
-                            ...requests,
-                            type.value
-                          ])
-                        : setField("requests")(
-                            requests.filter(x => x !== type.value)
-                          )
-                    }
-                    name={type.value}
-                    color="primary"
-                  />
-                }
-                label={type.label}
-              />
-            ))}
+            {provider && provider.requests.map(request => {
+              if (request.satisfied) return null;
+
+              const requestObj = providerRequestTypes.find(x => x.value === request.type);
+              if (!requestObj) return null;
+
+              return (
+                <FormControlLabel
+                  key={requestObj.value}
+                  control={
+                    <Checkbox
+                      checked={requests.includes(requestObj.value)}
+                      onChange={e =>
+                        e.target.checked
+                          ? setField("requests")([
+                              ...requests,
+                              requestObj.value
+                            ])
+                          : setField("requests")(
+                              requests.filter(x => x !== requestObj.value)
+                            )
+                      }
+                      name={requestObj.value}
+                      color="primary"
+                    />
+                  }
+                  label={requestObj.label}
+                />
+              )
+            })}
           </FormControl>
         </Grid>
         <Grid item xs={12}>

--- a/app/javascript/packs/pages/volunteer_signup/VolunteerStepper.jsx
+++ b/app/javascript/packs/pages/volunteer_signup/VolunteerStepper.jsx
@@ -138,7 +138,7 @@ export default function VolunteerStepper({ steps, location }) {
 
   const handleNext = () => {
     if (activeStep === steps.length - 1 && variables.over18 === false) {
-      setErrors(["You must be over 18 years old to volunteer."])
+      setErrors(["You must be over 18 years old to volunteer."]);
     }
     else if (activeStep === steps.length - 1) {
       createVolunteer({ variables: { ...variables, providerId: parseInt(queryId) }})
@@ -216,6 +216,7 @@ export default function VolunteerStepper({ steps, location }) {
             <CurrentStep
               onChange={onChange}
               setField={setField}
+              provider={provider}
               {...variables}
             />
             <div className={classes.buttons}>


### PR DESCRIPTION
* Changes the volunteer form to only show requests specific to the provider (previously showed all possible requests)
* Does not show requests that have been marked as satisfied by the provider