### PR TITLE
Fix the navbar spacing on mobile

### DIFF
--- a/app/javascript/packs/components/Header.jsx
+++ b/app/javascript/packs/components/Header.jsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles(theme => ({
   },
   logo: {
     [theme.breakpoints.down('sm')]: {
-      maxWidth: '140px',
+      maxWidth: '30vw',
       '& > svg': {
         maxWidth: '100%',
       }

--- a/app/javascript/packs/components/Nav.jsx
+++ b/app/javascript/packs/components/Nav.jsx
@@ -13,10 +13,6 @@ const useStyles = makeStyles(theme => ({
         marginLeft: theme.spacing(2),
       }
     },
-    [theme.breakpoints.down('xs')]: {
-      marginTop: '-5px'
-    },
-
     '& > [href="/"]': {
       [theme.breakpoints.down('xs')]: {
         display: 'none',
@@ -31,7 +27,7 @@ const useStyles = makeStyles(theme => ({
       letterSpacing: '1px',
       fontWeight: 'bold',
       [theme.breakpoints.down('xs')]: {
-        fontSize: '12px',
+        fontSize: '0.6rem'
       },
       '& > *:active': {
         color: theme.palette.primary,


### PR DESCRIPTION
## What does this PR do?
* On small devices, the nav links broke into two lines because they couldn't fit.

### Screenshots
#### Previously
![previously](https://user-images.githubusercontent.com/22860561/77544107-a4233f80-6eb9-11ea-9c67-0c8c8935eb44.png)


#### Updated
**iPhone 5**
![iphone 5 now](https://user-images.githubusercontent.com/22860561/77544101-a2f21280-6eb9-11ea-8222-5f25171eb34e.png)

##### iPhone 6
![iphone 6](https://user-images.githubusercontent.com/22860561/77543534-e5671f80-6eb8-11ea-836b-852f6610a466.png)
