### PR TITLE
Updates styling for homepage CTAs

### DIFF
--- a/app/javascript/packs/pages/home/About.jsx
+++ b/app/javascript/packs/pages/home/About.jsx
@@ -43,7 +43,7 @@ const contributors = [
     src: 'https://placehold.it/400x400',
   },
   {
-    name: 'Chandler Molson',
+    name: 'Chandler Moisen',
     role: 'Engineering',
     src: 'https://placehold.it/400x400',
   },

--- a/app/javascript/packs/pages/home/SplitSection.jsx
+++ b/app/javascript/packs/pages/home/SplitSection.jsx
@@ -37,10 +37,14 @@ const useStyles = makeStyles(theme => ({
     },
   },
   actionButton: {
+    boxShadow: 'none',
     fontSize: '20px',
+    lineHeight: '28px',
     padding: '10px 20px',
-    boxShadow: 'none'
-  }
+  },
+  buttonLink: {
+    textDecoration: 'none',
+  },
 }));
 
 const SplitSection = () => {
@@ -66,7 +70,11 @@ const SplitSection = () => {
           >
             Make requests for meals, supplies, or anything else you need. Share a link with your friends and family.
           </Typography>
-          <Link to="/provider-signup"><Button className={classes.actionButton} size="large" variant="contained" color="primary" elevation={0}>Request Help</Button></Link>
+          <Link to="/provider-signup" className={classes.buttonLink}>
+            <Button className={classes.actionButton} size="large" variant="contained" color="primary" elevation={0}>
+              Request Help
+            </Button>
+          </Link>
         </Box>
       </Box>
       <Box bgcolor={'secondary.800'} display="flex">
@@ -88,7 +96,11 @@ const SplitSection = () => {
           >
             Offer your support to local doctors, nurses, and hospital workers in your community. You choose who and how to help.
           </Typography>
-          <Link to="/browse"><Button className={classes.actionButton} size="large" variant="contained" color="secondary" elevation={0}>Volunteer Now</Button></Link>
+          <Link to="/browse" className={classes.buttonLink}>
+            <Button className={classes.actionButton} size="large" variant="contained" color="secondary" elevation={0}>
+              Volunteer Now
+            </Button>
+          </Link>
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
https://trello.com/c/vdz4tncZ/83-adjust-button-link-style-to-remove-underlining

## Overview

Removes text decoration from homepage CTA's:

![image](https://user-images.githubusercontent.com/4118615/77600230-9aabce80-6edd-11ea-8120-6feea067d8ca.png)
