### PR TITLE
Add bottom margin to allow space for feedback widget

### DIFF
--- a/app/javascript/packs/pages/BrowseRequests.jsx
+++ b/app/javascript/packs/pages/BrowseRequests.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import Box from "@material-ui/core/Box";
 
 const BrowseRequests = () => (
-  <iframe class="airtable-embed airtable-dynamic-height" src="https://airtable.com/embed/shr3okipJzPefgm2X?backgroundColor=cyan" frameborder="0" onmousewheel="" width="100%" height="1693" style={{background: "transparent", border: "1px solid #ccc"}}></iframe>
+  <Box mb={10}>
+    <iframe class="airtable-embed airtable-dynamic-height" src="https://airtable.com/embed/shr3okipJzPefgm2X?backgroundColor=cyan" frameborder="0" onmousewheel="" width="100%" height="1693" style={{background: "transparent", border: "1px solid #ccc"}}></iframe>
+  </Box>
 );
 
 export default BrowseRequests;

--- a/app/javascript/packs/pages/edit_provider/EditProvider.jsx
+++ b/app/javascript/packs/pages/edit_provider/EditProvider.jsx
@@ -15,6 +15,7 @@ import useTokenEntity, {
 const useStyles = makeStyles(theme => ({
   paper: {
     marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(10),
     padding: theme.spacing(2),
     [theme.breakpoints.up(600 + theme.spacing(3) * 2)]: {
       marginTop: theme.spacing(6),
@@ -62,7 +63,7 @@ const EditProvider = () => {
   const onChange = e => {
     setField(e.target.name)(e.target.value);
   };
-  
+
   return (
     <Paper className={classes.paper}>
       <Typography

--- a/app/javascript/packs/pages/provider_signup/SignupStepper.jsx
+++ b/app/javascript/packs/pages/provider_signup/SignupStepper.jsx
@@ -16,6 +16,7 @@ import Snackbar from "@material-ui/core/Snackbar";
 const useStyles = makeStyles(theme => ({
   paper: {
     marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(10),
     padding: theme.spacing(2),
     [theme.breakpoints.up(600 + theme.spacing(3) * 2)]: {
       marginTop: theme.spacing(6),

--- a/app/javascript/packs/pages/volunteer_signup/VolunteerStepper.jsx
+++ b/app/javascript/packs/pages/volunteer_signup/VolunteerStepper.jsx
@@ -16,6 +16,7 @@ import queryString from 'query-string';
 const useStyles = makeStyles(theme => ({
   paper: {
     marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(10),
     padding: theme.spacing(2),
     [theme.breakpoints.up(600 + theme.spacing(3) * 2)]: {
       marginTop: theme.spacing(6),


### PR DESCRIPTION
https://trello.com/c/NJJyFvpC/104-mobile-feedback-widget-covers-form-buttons

Fix for mobile, but I included the bottom margin for all breakpoints so the "next" button doesn't have to be so close to the bottom of the page on smaller laptops.

<img width="374" alt="Screen Shot 2020-03-26 at 7 55 31 PM" src="https://user-images.githubusercontent.com/43832282/77708794-76182b00-6f9f-11ea-9e33-987cf727b57f.png">

<img width="1234" alt="Screen Shot 2020-03-26 at 8 42 03 PM" src="https://user-images.githubusercontent.com/43832282/77709701-4e769200-6fa2-11ea-823d-67a0cb380c68.png">



