### PR TITLE
Add padding to homepage SplitSection

### DIFF
--- a/app/javascript/packs/pages/home/SplitSection.jsx
+++ b/app/javascript/packs/pages/home/SplitSection.jsx
@@ -13,6 +13,7 @@ const useStyles = makeStyles(theme => ({
       width: "100%",
       alignSelf: 'center',
       justifyContent: "center",
+      padding: theme.spacing(4, 2),
       [theme.breakpoints.up('md')]: {
         width: "50%",
         minHeight: '650px'
@@ -28,7 +29,12 @@ const useStyles = makeStyles(theme => ({
       [theme.breakpoints.up('md')]: {
         paddingLeft: '80px',
         justifyContent: "flex-start"
-      }
+      },
+      '& > *:first-child': {
+        [theme.breakpoints.up('md')]: {
+          paddingTop: '15px'
+        }
+      },
     },
     flexDirection: 'column',
     [theme.breakpoints.up('md')]: {
@@ -77,7 +83,7 @@ const SplitSection = () => {
         </Box>
       </Box>
       <Box bgcolor={'secondary.800'} display="flex">
-        <Box alignSelf="center" style={{maxWidth: '500px', paddingTop: '15px', textAlign: 'center'}}>
+        <Box alignSelf="center" style={{maxWidth: '500px', textAlign: 'center'}}>
           <Volunteers />
           <Typography
             component="h2"


### PR DESCRIPTION
https://trello.com/c/D1c19PKm/106-mobile-home-page-cta-buttons-margin-fix

Adds even padding for both sections of the homepage SplitSection on mobile.

<img width="347" alt="Screen Shot 2020-03-26 at 9 53 14 PM" src="https://user-images.githubusercontent.com/43832282/77713527-f5602b80-6fac-11ea-83b7-780ede71942a.png">
