### PR TITLE
move 18+ checkbox to the bottom of the offer form

### DIFF
--- a/app/javascript/packs/pages/volunteer_signup/VolunteerAddressForm.jsx
+++ b/app/javascript/packs/pages/volunteer_signup/VolunteerAddressForm.jsx
@@ -42,27 +42,6 @@ export default function VolunteerAddressForm({
       </Typography>
 
       <Grid container spacing={3}>
-        <Grid item xs={12}>
-          <FormControl>
-            <StyledFormLabel required id="type-select-label">
-              I am over 18 years old.
-            </StyledFormLabel>
-            <FormControlLabel
-              control={
-                <Checkbox
-                  checked={over18}
-                  onChange={(e) =>
-                    e.target.checked
-                      ? setField("over18")(true)
-                      : setField("over18")(false)
-                  }
-                  name="over18"
-                  color="primary"
-                />
-              }
-            />
-          </FormControl>
-        </Grid>
         <Grid item xs={12} sm={6}>
           <StyledTextField
             required
@@ -162,6 +141,27 @@ export default function VolunteerAddressForm({
           <FormHelperText>
             If you are responding to a public request, this is encouraged.
           </FormHelperText>
+        </Grid>
+        <Grid item xs={12}>
+          <FormControl>
+            <StyledFormLabel required id="type-select-label">
+              I am over 18 years old.
+            </StyledFormLabel>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  checked={over18}
+                  onChange={(e) =>
+                    e.target.checked
+                      ? setField("over18")(true)
+                      : setField("over18")(false)
+                  }
+                  name="over18"
+                  color="primary"
+                />
+              }
+            />
+          </FormControl>
         </Grid>
       </Grid>
     </React.Fragment>


### PR DESCRIPTION
https://trello.com/c/wvwPkhLw/165-move-im-18-checkbox-to-bottom-of-offer-form

I moved the 18+ checkbox to the bottom of the offer form for volunteers.

Old:
<img width="760" alt="Screenshot 2020-03-30 at 18 11 22" src="https://user-images.githubusercontent.com/41751845/77942602-bfc08880-72b3-11ea-9310-e48178429dca.png">

New:
<img width="998" alt="Screenshot 2020-03-30 at 18 12 14" src="https://user-images.githubusercontent.com/41751845/77942620-c7802d00-72b3-11ea-868a-4141c6a67d32.png">
