### PR TITLE
Include the link to the request in the volunteer confirmation email

### DIFF
--- a/app/graphql/mutations/create_volunteer.rb
+++ b/app/graphql/mutations/create_volunteer.rb
@@ -53,7 +53,7 @@ class Mutations::CreateVolunteer < Mutations::BaseMutation
 
     if volunteer.save
       linked_token = LinkCreator.create_token(volunteer)
-      VolunteerMailer.with(linked_token: linked_token).response_created_email.deliver_later
+      VolunteerMailer.with(linked_token: linked_token, provider: provider).response_created_email.deliver_later
       ProviderMailer.with(provider: provider, volunteer: volunteer, response: response).volunteer_response_email.deliver_later
 
       {

--- a/app/mailers/volunteer_mailer.rb
+++ b/app/mailers/volunteer_mailer.rb
@@ -1,6 +1,8 @@
 class VolunteerMailer < ApplicationMailer
   def response_created_email
+    provider = params[:provider]
     @volunteer = params[:linked_token].entity
+    @request_url = HOST_AND_SCHEME + '/providers/' + provider.to_param
     # @edit_url = HOST_AND_SCHEME + '/volunteers/' + params[:linked_token].token + '/edit'
     mail(to: @volunteer.email, subject: 'Your help response has been created.')
   end

--- a/app/views/volunteer_mailer/response_created_email.erb
+++ b/app/views/volunteer_mailer/response_created_email.erb
@@ -1,5 +1,13 @@
 <h1 style="margin-top: 0; color: #333333; font-size: 22px; font-weight: bold; text-align: left;" align="left"><%= @volunteer.first_name %>, your help response has been created. Thank you!</h1>
 <p style="font-size: 16px; line-height: 1.625; color: #51545E; margin: .4em 0 1.1875em;">You should hear back from the medical provider soon to coordinate.</p>
+<p style="font-size: 16px; line-height: 1.625; color: #51545E; margin: .4em 0 1.1875em;">Here is a public link to the help request that you volunteered to help with:</p>
+<table align='center' style='text-align:center'>
+  <tr>
+    <td align='center' style='text-align:center'>
+<p style="font-size: 16px; line-height: 1.625; color: #51545E; margin: .4em 0 1.1875em;"><strong><a href="<%= @request_url %>"><%= @request_url %></a></strong></p>
+    </td>
+  </tr>
+</table>
 <p style="font-size: 16px; line-height: 1.625; color: #51545E; margin: .4em 0 1.1875em;">We truly appreciate your help. Please reach out to us if you have any  suggestions.</p>
 <p style="font-size: 16px; line-height: 1.625; color: #51545E; margin: .4em 0 1.1875em;">Best,
 <br />The HospitalHero Team</p>


### PR DESCRIPTION
## What does this PR do?

* update the `create_volunteer` email template to include the request
url

* pass `provider` to the mailer method that handles
volunteer confirmation emails


## Screenshot

![screenshot](https://user-images.githubusercontent.com/22860561/78377838-d24f0080-75d8-11ea-88d5-d806a6ce6271.png)
