### PR TITLE
add spacing in between nav items

### DIFF
--- a/app/javascript/packs/components/Nav.jsx
+++ b/app/javascript/packs/components/Nav.jsx
@@ -34,6 +34,9 @@ const useStyles = makeStyles((theme) => ({
       color: theme.palette.primary,
       borderBottomColor: theme.palette.primary.main,
     },
+    "&:not(:last-child)": {
+      marginRight: "1.5rem",
+    },
     "&:nth-of-type(1n+1)": {
       marginLeft: theme.spacing(4),
       [theme.breakpoints.down("sm")]: {


### PR DESCRIPTION
https://trello.com/c/8xLn9jh5/177-ui-style-changes-running-list

Added right margin to the navbar items (but not after the last item).

Old:
<img width="1431" alt="Screenshot 2020-04-07 at 19 26 26" src="https://user-images.githubusercontent.com/41751845/78706295-be700b00-7906-11ea-83ac-baa523a07282.png">

New:
<img width="1435" alt="Screenshot 2020-04-07 at 19 32 21" src="https://user-images.githubusercontent.com/41751845/78706317-c4fe8280-7906-11ea-98d0-25b461863d0c.png">