### PR TITLE
Remove paper components

### DIFF
--- a/app/javascript/packs/pages/browse_requests/BrowseRequests.jsx
+++ b/app/javascript/packs/pages/browse_requests/BrowseRequests.jsx
@@ -3,7 +3,6 @@ import { makeStyles } from "@material-ui/core/styles";
 import { Link } from "react-router-dom";
 import Container from "@material-ui/core/Container";
 import Typography from "@material-ui/core/Container";
-import Paper from "@material-ui/core/Paper";
 import Box from "@material-ui/core/Box";
 import InputBase from "@material-ui/core/InputBase";
 import SearchIcon from "@material-ui/icons/Search";
@@ -147,11 +146,7 @@ export default function BrowseRequests() {
       {isSuccess && (
         <Container className={classes.heroContent}>
           <Box mb={4} textAlign="center">
-            <Typography
-              variant="h5"
-              gutterBottom
-              className={classes.successText}
-            >
+            <Typography variant="h5" className={classes.successText}>
               Thank you so much for volunteering!
             </Typography>
             <Typography variant="subtitle1" className={classes.successText}>

--- a/app/javascript/packs/pages/browse_requests/BrowseRequests.jsx
+++ b/app/javascript/packs/pages/browse_requests/BrowseRequests.jsx
@@ -143,9 +143,9 @@ export default function BrowseRequests() {
   };
 
   return (
-    <Box mb={6}>
-      <Paper className={classes.heroContent}>
-        {isSuccess && (
+    <Box mb={6} mt={10}>
+      {isSuccess && (
+        <Container className={classes.heroContent}>
           <Box mb={4} textAlign="center">
             <Typography
               variant="h5"
@@ -158,8 +158,8 @@ export default function BrowseRequests() {
               You should hear back from the medical provider soon.
             </Typography>
           </Box>
-        )}
-      </Paper>
+        </Container>
+      )}
       <VolunteerInstructions />
       <Container className={classes.search}>
         <div className={classes.searchIcon}>

--- a/app/javascript/packs/pages/browse_requests/ProviderList.jsx
+++ b/app/javascript/packs/pages/browse_requests/ProviderList.jsx
@@ -48,7 +48,7 @@ export default function ProviderList({
 }) {
   const classes = useStyles();
   return (
-    <Paper>
+    <div>
       <Container>
         <Box>
           {providers.map(
@@ -131,6 +131,6 @@ export default function ProviderList({
           <Button onClick={() => onNext(pageInfo.endCursor)}>Next Page</Button>
         )}
       </Container>
-    </Paper>
+    </div>
   );
 }

--- a/app/javascript/packs/pages/browse_requests/ProviderList.jsx
+++ b/app/javascript/packs/pages/browse_requests/ProviderList.jsx
@@ -2,7 +2,6 @@ import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import Container from "@material-ui/core/Container";
 import Typography from "@material-ui/core/Container";
-import Paper from "@material-ui/core/Paper";
 import Box from "@material-ui/core/Box";
 import Button from "@material-ui/core/Button";
 import Grid from "@material-ui/core/Grid";
@@ -38,6 +37,9 @@ const useStyles = makeStyles((theme) => ({
     color: "inherit",
     textDecoration: "inherit",
   },
+  firstName: {
+    fontWeight: "bold",
+  },
 }));
 
 export default function ProviderList({
@@ -48,7 +50,7 @@ export default function ProviderList({
 }) {
   const classes = useStyles();
   return (
-    <div>
+    <Box>
       <Container>
         <Box>
           {providers.map(
@@ -66,20 +68,19 @@ export default function ProviderList({
               },
               index
             ) => {
-              const className = index % 2 == 0 ? "background" : "";
               return (
                 <Box
                   key={index}
                   p={2}
-                  className={index % 2 == 0 && classes.background}
+                  className={index % 2 == 0 ? classes.background : undefined}
                 >
                   <Link
                     to={`/providers/${id}`}
                     className={classes.providerInfoText}
                   >
-                    <Grid container spacing={1}>
-                      <Grid item xs={6} spacing={2}>
-                        <Typography component="th" scope="row">
+                    <Grid container>
+                      <Grid item xs={6}>
+                        <Typography className={classes.firstName} scope="row">
                           {firstName}
                         </Typography>
                         {neighborhood ? (
@@ -108,7 +109,7 @@ export default function ProviderList({
                           })}
                         </Typography>
                       </Grid>
-                      <Grid item xs={6} spacing={2}>
+                      <Grid item xs={6}>
                         <Typography>{`${responseCount} ${
                           responseCount == 1 ? "Offer" : "Offers"
                         }`}</Typography>
@@ -131,6 +132,6 @@ export default function ProviderList({
           <Button onClick={() => onNext(pageInfo.endCursor)}>Next Page</Button>
         )}
       </Container>
-    </div>
+    </Box>
   );
 }

--- a/app/javascript/packs/pages/browse_requests/VolunteerInstructions.jsx
+++ b/app/javascript/packs/pages/browse_requests/VolunteerInstructions.jsx
@@ -51,12 +51,7 @@ export default function VolunteerInstructions() {
   const classes = useStyles();
   return (
     <Container maxWidth="lg" className={classes.volunteerContainer}>
-      <Typography
-        component="h1"
-        align="center"
-        color="textPrimary"
-        gutterBottom
-      >
+      <Typography component="h1" align="center" color="textPrimary">
         Volunteer Now
       </Typography>
       <Container className={classes.volunteerTextContainer}>


### PR DESCRIPTION
* The /volunteer page inherited some new drop shadow styling in weird places (currently on staging) because it's using Paper components. I replaced Paper with regular containers with margins.

https://trello.com/c/sjDVLcwg/204-remove-styled-paper-components-from-volunteer-page

* Also fixed the React warnings on this page. Basically clean up from when I built this really quickly!