### PR TITLE
Send HH an email when a volunteer response is created

### DIFF
--- a/app/graphql/mutations/create_volunteer.rb
+++ b/app/graphql/mutations/create_volunteer.rb
@@ -54,7 +54,7 @@ class Mutations::CreateVolunteer < Mutations::BaseMutation
     if volunteer.save
       linked_token = LinkCreator.create_token(volunteer)
       VolunteerMailer.with(linked_token: linked_token, provider: provider).response_created_email.deliver_later
-      ProviderMailer.with(provider: provider, volunteer: volunteer, response: response).volunteer_response_email.deliver_later
+      ProviderNotifications.send_volunteer_response_created_notifications(provider, volunteer, response)
 
       {
         volunteer: volunteer,

--- a/app/mailers/internal_mailer.rb
+++ b/app/mailers/internal_mailer.rb
@@ -6,4 +6,12 @@ class InternalMailer < ApplicationMailer
     @edit_url = HOST_AND_SCHEME + '/providers/' + params[:linked_token].token + '/edit'
     mail(template_path: 'provider_mailer', to: INTERNAL_EMAIL, from: @provider.email, reply_to: @provider.email, subject: 'Your help request has been created.')
   end
+
+  def volunteer_response_email
+    @provider = params[:provider]
+    @volunteer = params[:volunteer]
+    @response = params[:response]
+    mail(template_path: "provider_mailer", to: INTERNAL_EMAIL, from: @volunteer.email, reply_to: @volunteer.email,
+      subject: "Offer made to #{@provider.first_name} from #{@volunteer.first_name} (RequestId: #{@provider.id})")
+  end
 end

--- a/app/mailers/internal_mailer.rb
+++ b/app/mailers/internal_mailer.rb
@@ -11,7 +11,7 @@ class InternalMailer < ApplicationMailer
     @provider = params[:provider]
     @volunteer = params[:volunteer]
     @response = params[:response]
-    mail(template_path: "provider_mailer", to: INTERNAL_EMAIL, from: @volunteer.email, reply_to: @volunteer.email,
+    mail(template_path: "provider_mailer", to: INTERNAL_EMAIL, reply_to: @volunteer.email,
       subject: "Offer made to #{@provider.first_name} from #{@volunteer.first_name} (RequestId: #{@provider.id})")
   end
 end

--- a/app/services/provider_notifications.rb
+++ b/app/services/provider_notifications.rb
@@ -4,5 +4,10 @@ class ProviderNotifications
       ProviderMailer.with(linked_token: linked_token).request_created_email.deliver_later
       InternalMailer.with(linked_token: linked_token).request_created_email.deliver_later
     end
+
+    def send_volunteer_response_created_notifications(provider, volunteer, response)
+      ProviderMailer.with(provider: provider, volunteer: volunteer, response: response).volunteer_response_email.deliver_later
+      InternalMailer.with(provider: provider, volunteer: volunteer, response: response).volunteer_response_email.deliver_later
+    end
   end
 end

--- a/spec/graphql/mutations/create_volunteer_spec.rb
+++ b/spec/graphql/mutations/create_volunteer_spec.rb
@@ -29,6 +29,7 @@ describe Mutations::CreateVolunteer, type: :request do
   it "creates a Volunteer and sends an email" do
     provider = create(:provider)
 
+    expect(ProviderNotifications).to receive(:send_volunteer_response_created_notifications)
     expect do
       expect do
         post '/graphql',
@@ -44,7 +45,7 @@ describe Mutations::CreateVolunteer, type: :request do
                      }.to_json,
              headers: { "CONTENT_TYPE" => "application/json" }
       end.to change { Volunteer.count }.by(1)
-    end.to have_enqueued_job(ActionMailer::MailDeliveryJob).exactly(2).times
+    end.to have_enqueued_job(ActionMailer::MailDeliveryJob).once
 
     json = JSON.parse(response.body)
     expect(json['data']['createVolunteer']['volunteer']).to include("firstName" => "bob")

--- a/spec/services/provider_notifications.rb
+++ b/spec/services/provider_notifications.rb
@@ -11,4 +11,20 @@ describe ProviderNotifications do
         'InternalMailer', 'request_created_email', 'deliver_now', any_args
     )
   end
+
+  describe ".send_volunteer_response_created_notifications" do
+    it "sends emails regarding a volunteer response being created to the provider and help desk" do
+      provider = Provider.new(id: 1)
+      volunteer = Volunteer.new(id: 1)
+      response = Response.new(id: 1)
+
+      expect {
+        ProviderNotifications.send_volunteer_response_created_notifications(provider, volunteer, response)
+      }.to have_enqueued_job.on_queue("mailers").with(
+          "ProviderMailer", "volunteer_response_email", "deliver_now", any_args
+      ).and have_enqueued_job.on_queue('mailers').with(
+        'InternalMailer', 'volunteer_response_email', 'deliver_now', any_args
+      )
+    end
+  end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/EP1E74dz/226-notify-hh-when-volunteer-makes-direct-offer-to-provider

Send an email to hello@hospitalhero.care when Volunteer submits an Offer: 
- The "From" should be the Volunteer's name/email. 
- The subject is"Offer made to **Provider name** from **Volunteer name** (**RequestId: request number**)".
- The body of the email is the same as email to provider