### PR TITLE
Don't set from on provider internal mailer.

### DIFF
--- a/app/mailers/internal_mailer.rb
+++ b/app/mailers/internal_mailer.rb
@@ -4,6 +4,6 @@ class InternalMailer < ApplicationMailer
     @provider = params[:linked_token].entity
     @request_url = HOST_AND_SCHEME + '/providers/' + @provider.to_param
     @edit_url = HOST_AND_SCHEME + '/providers/' + params[:linked_token].token + '/edit'
-    mail(template_path: 'provider_mailer', to: INTERNAL_EMAIL, reply_to: @provider.email, subject: 'Your help request has been created.')
+    mail(template_path: 'provider_mailer', to: INTERNAL_EMAIL, reply_to: @provider.email, subject: 'Request from ' + @provider.full_name)
   end
 end

--- a/app/mailers/internal_mailer.rb
+++ b/app/mailers/internal_mailer.rb
@@ -4,6 +4,6 @@ class InternalMailer < ApplicationMailer
     @provider = params[:linked_token].entity
     @request_url = HOST_AND_SCHEME + '/providers/' + @provider.to_param
     @edit_url = HOST_AND_SCHEME + '/providers/' + params[:linked_token].token + '/edit'
-    mail(template_path: 'provider_mailer', to: INTERNAL_EMAIL, reply_to: @provider.email, subject: 'Request from ' + @provider.full_name)
+    mail(template_path: 'provider_mailer', to: INTERNAL_EMAIL, reply_to: @provider.email, subject: "Request from #{@provider.full_name} (Request ID: #{@provider.id})")
   end
 end

--- a/app/mailers/internal_mailer.rb
+++ b/app/mailers/internal_mailer.rb
@@ -4,6 +4,6 @@ class InternalMailer < ApplicationMailer
     @provider = params[:linked_token].entity
     @request_url = HOST_AND_SCHEME + '/providers/' + @provider.to_param
     @edit_url = HOST_AND_SCHEME + '/providers/' + params[:linked_token].token + '/edit'
-    mail(template_path: 'provider_mailer', to: INTERNAL_EMAIL, from: @provider.email, reply_to: @provider.email, subject: 'Your help request has been created.')
+    mail(template_path: 'provider_mailer', to: INTERNAL_EMAIL, reply_to: @provider.email, subject: 'Your help request has been created.')
   end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -24,4 +24,8 @@ class Provider < ApplicationRecord
     errors.add(:base, "You must select at lease one request") unless requests.length > 0
     errors.add(:requests, "must all have fields satisfied and have a valid type") unless requests.all? { |r| r.is_a?(Hash) && REQUEST_TYPES[r["type"]] && r.has_key?("satisfied") }
   end
+
+  def full_name
+    [first_name, last_name].select(&:present?).join(' ')
+  end
 end


### PR DESCRIPTION
> (The 'From' address you supplied (redacted) is not a Sender Signature on your account. Please add and confirm this address in order to be able to use it in the 'From' field of your messages.):

Without additional work to verify sender emails via the Postmark API, we're limited to sending from pre-authorized emails.

For now, we will send an email with the provider's full name in the subject to keep unique tickets in Zendesk. They will all be bucketed in the same user.