### PR TITLE
Add asset host for mailer in non-dev environments

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -62,6 +62,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
   config.action_mailer.delivery_method = :postmark
   config.action_mailer.postmark_settings = { api_token: ENV["POSTMARK_API_TOKEN"] }
+  config.action_mailer.asset_host = ENV['HOST_AND_SCHEME']
   # config.action_mailer.delivery_method = :smtp
   # config.action_mailer.smtp_settings = {
   #   :user_name => ENV['SENDGRID_USERNAME'],


### PR DESCRIPTION
The config `config.action_mailer.asset_host` is not defined in non-dev environments. This can cause images to be missing when sending emails.

The following is reproduced in staging:
![Screen Shot 2020-04-16 at 7 15 16 PM](https://user-images.githubusercontent.com/15841903/79515451-a854ff80-8016-11ea-9ab8-645fa4dbde6a.png)
