### PR TITLE
Forward internal mail through gmail

### DIFF
--- a/app/mailers/internal_mailer.rb
+++ b/app/mailers/internal_mailer.rb
@@ -1,5 +1,5 @@
 class InternalMailer < ApplicationMailer
-  INTERNAL_EMAIL = 'hello@hospitalhero.care'
+  INTERNAL_EMAIL = 'hospitalheroticket@gmail.com'
   def request_created_email
     @provider = params[:linked_token].entity
     @request_url = HOST_AND_SCHEME + '/providers/' + @provider.to_param


### PR DESCRIPTION
**From Zendesk docs**
Detected email as being from a system user | Email  generated by a mail server (for example, messages sent from addresses  beginning with mail-daemon@ and postmaster@) are suspended because it is  assumed that they are not intended to be support requests. | Mail from these addresses will need to be sent from or redirected through non-system addresses.
-- | -- | --

I created a gmail account with a forwarding rule on all emails from no-reply@hospitalhero.care. Those emails will forward through to hello@hospitalhero.care which will create a zendesk ticket.