### PR TITLE
Send support emails from team@

### DIFF
--- a/app/javascript/packs/feedadoc.jsx
+++ b/app/javascript/packs/feedadoc.jsx
@@ -98,9 +98,6 @@ function App() {
                     <BrowseRequests />
                   </Container>
                 </Route>
-                <Route path="/providers">
-                  <ProviderLandingPage />
-                </Route>
                 <Route path="/providers/:token/edit">
                   <Container maxWidth="md">
                     <EditProvider />
@@ -110,6 +107,9 @@ function App() {
                 <Route path="/how-it-works">
                   <ScrollToTopOnMount />
                   <HowItWorks />
+                </Route>
+                <Route path="/providers">
+                  <ProviderLandingPage />
                 </Route>
                 <Route path="/">
                   <ScrollToTopOnMount />

--- a/app/mailers/internal_mailer.rb
+++ b/app/mailers/internal_mailer.rb
@@ -4,7 +4,7 @@ class InternalMailer < ApplicationMailer
     @provider = params[:linked_token].entity
     @request_url = HOST_AND_SCHEME + '/providers/' + @provider.to_param
     @edit_url = HOST_AND_SCHEME + '/providers/' + params[:linked_token].token + '/edit'
-    mail(template_path: 'provider_mailer', to: INTERNAL_EMAIL, reply_to: @provider.email, subject: "Request from #{@provider.full_name} (Request ID: #{@provider.id})")
+    mail(template_path: 'provider_mailer', from: INTERNAL_EMAIL, reply_to: @provider.email, subject: "Request from #{@provider.full_name} (Request ID: #{@provider.id})")
   end
 
   def volunteer_response_email

--- a/app/mailers/internal_mailer.rb
+++ b/app/mailers/internal_mailer.rb
@@ -1,5 +1,5 @@
 class InternalMailer < ApplicationMailer
-  INTERNAL_EMAIL = 'hospitalheroticket@gmail.com'
+  INTERNAL_EMAIL = 'team@hospitalhero.care'
   def request_created_email
     @provider = params[:linked_token].entity
     @request_url = HOST_AND_SCHEME + '/providers/' + @provider.to_param

--- a/app/mailers/internal_mailer.rb
+++ b/app/mailers/internal_mailer.rb
@@ -1,17 +1,18 @@
 class InternalMailer < ApplicationMailer
-  INTERNAL_EMAIL = 'hospitalheroticket@gmail.com'
+  INTERNAL_TEAM_EMAIL = 'team@hospitalhero.care'
+  INTERNAL_SUPPORT_EMAIL = 'hello@hospitalhero.care'
   def request_created_email
     @provider = params[:linked_token].entity
     @request_url = HOST_AND_SCHEME + '/providers/' + @provider.to_param
     @edit_url = HOST_AND_SCHEME + '/providers/' + params[:linked_token].token + '/edit'
-    mail(template_path: 'provider_mailer', to: INTERNAL_EMAIL, reply_to: @provider.email, subject: "Request from #{@provider.full_name} (Request ID: #{@provider.id})")
+    mail(template_path: 'provider_mailer', from: INTERNAL_TEAM_EMAIL, to: INTERNAL_SUPPORT_EMAIL, reply_to: @provider.email, subject: "Request from #{@provider.full_name} (Request ID: #{@provider.id})")
   end
 
   def volunteer_response_email
     @provider = params[:provider]
     @volunteer = params[:volunteer]
     @response = params[:response]
-    mail(template_path: "provider_mailer", to: INTERNAL_EMAIL, reply_to: @volunteer.email,
+    mail(template_path: "provider_mailer", to: INTERNAL_SUPPORT_EMAIL, from: INTERNAL_TEAM_EMAIL, reply_to: @volunteer.email,
       subject: "Offer made to #{@provider.first_name} from #{@volunteer.first_name} (RequestId: #{@provider.id})")
   end
 end


### PR DESCRIPTION
When a provider request is created, a zendesk ticket is made. Currently, that ticket ends up in suspended because it's detected to be from an internal user. This is an attempt to send from team@ which hopefully fixes that.

Also fixes an issue where the provider success page doesn't load properly due to priority in the router.